### PR TITLE
contrôle on/off de la LED

### DIFF
--- a/LedControl/LedControl.ino
+++ b/LedControl/LedControl.ino
@@ -1,0 +1,16 @@
+/*
+ * Ce code montre le fonctionnement de la LED intégrée à l'ESP32-C6
+ */
+ 
+void setup() {
+  pinMode(RGB_BUILTIN, OUTPUT);
+  digitalWrite(RGB_BUILTIN, LOW);
+  delay(1000);
+}
+
+void loop() {
+  digitalWrite(RGB_BUILTIN, HIGH);
+  delay(1000);
+  digitalWrite(RGB_BUILTIN, LOW);
+  delay(1000);
+}


### PR DESCRIPTION
Implémentation d’un module permettant de contrôler la LED intégrée de l’ESP32-C6.
La LED clignote à intervalles réguliers à l’aide de la broche définie (RGB_BUILTIN).
Ce module sert de base pour tester et valider le fonctionnement du matériel et l’environnement de développement.